### PR TITLE
chore: update npm target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@
 
 ## v1.1.1
 
-[compare changes](https://github.com/fuentesloic/nuxt3-stripe/compare/v1.1.0...v1.1.1)
+[compare changes](https://github.com/fuentesloic/nuxt-stripe/compare/v1.1.0...v1.1.1)
 
 
 ### 🩹 Fixes
 
-  - Contributors in changelog ([f30914b](https://github.com/fuentesloic/nuxt3-stripe/commit/f30914b))
+  - Contributors in changelog ([f30914b](https://github.com/fuentesloic/nuxt-stripe/commit/f30914b))
 
 ### 🏡 Chore
 
-  - Package naming as no ownership in @nuxtjs ([81b710d](https://github.com/fuentesloic/nuxt3-stripe/commit/81b710d))
+  - Package naming as no ownership in @nuxtjs ([81b710d](https://github.com/fuentesloic/nuxt-stripe/commit/81b710d))
 
 ### ❤️  Contributors
 
@@ -23,34 +23,34 @@
 
 ### 🚀 Enhancements
 
-  - Adding typing for server side ([bc6ec38](https://github.com/fuentesloic/nuxt3-stripe/commit/bc6ec38))
-  - Adding license ([e267906](https://github.com/fuentesloic/nuxt3-stripe/commit/e267906))
-  - Remove locale ([#8](https://github.com/fuentesloic/nuxt3-stripe/pull/8))
-  - Client playground UI ([#10](https://github.com/fuentesloic/nuxt3-stripe/pull/10))
+  - Adding typing for server side ([bc6ec38](https://github.com/fuentesloic/nuxt-stripe/commit/bc6ec38))
+  - Adding license ([e267906](https://github.com/fuentesloic/nuxt-stripe/commit/e267906))
+  - Remove locale ([#8](https://github.com/fuentesloic/nuxt-stripe/pull/8))
+  - Client playground UI ([#10](https://github.com/fuentesloic/nuxt-stripe/pull/10))
 
 ### 🩹 Fixes
 
-  - Add alias via tsConfig paths ([#9](https://github.com/fuentesloic/nuxt3-stripe/pull/9))
+  - Add alias via tsConfig paths ([#9](https://github.com/fuentesloic/nuxt-stripe/pull/9))
 
 ### 💅 Refactors
 
-  - Use template dst to define the final path ([a1584df](https://github.com/fuentesloic/nuxt3-stripe/commit/a1584df))
+  - Use template dst to define the final path ([a1584df](https://github.com/fuentesloic/nuxt-stripe/commit/a1584df))
 
 ### 📖 Documentation
 
-  - Update documentation ([1e5c0aa](https://github.com/fuentesloic/nuxt3-stripe/commit/1e5c0aa))
+  - Update documentation ([1e5c0aa](https://github.com/fuentesloic/nuxt-stripe/commit/1e5c0aa))
 
 ### 🏡 Chore
 
-  - Initial commit ([f1cee19](https://github.com/fuentesloic/nuxt3-stripe/commit/f1cee19))
-  - Adding code of conduct ([873d054](https://github.com/fuentesloic/nuxt3-stripe/commit/873d054))
-  - Adding runtime transpilationg ([757a586](https://github.com/fuentesloic/nuxt3-stripe/commit/757a586))
-  - Updating path and runtime folders ([6d4fa8d](https://github.com/fuentesloic/nuxt3-stripe/commit/6d4fa8d))
-  - Fix path of import ([926d239](https://github.com/fuentesloic/nuxt3-stripe/commit/926d239))
-  - Clean imports ([bc3a877](https://github.com/fuentesloic/nuxt3-stripe/commit/bc3a877))
-  - Cleanup defu ([204483d](https://github.com/fuentesloic/nuxt3-stripe/commit/204483d))
-  - Updating type definition with add template ([0c80308](https://github.com/fuentesloic/nuxt3-stripe/commit/0c80308))
-  - Update package name ([b93dea5](https://github.com/fuentesloic/nuxt3-stripe/commit/b93dea5))
+  - Initial commit ([f1cee19](https://github.com/fuentesloic/nuxt-stripe/commit/f1cee19))
+  - Adding code of conduct ([873d054](https://github.com/fuentesloic/nuxt-stripe/commit/873d054))
+  - Adding runtime transpilationg ([757a586](https://github.com/fuentesloic/nuxt-stripe/commit/757a586))
+  - Updating path and runtime folders ([6d4fa8d](https://github.com/fuentesloic/nuxt-stripe/commit/6d4fa8d))
+  - Fix path of import ([926d239](https://github.com/fuentesloic/nuxt-stripe/commit/926d239))
+  - Clean imports ([bc3a877](https://github.com/fuentesloic/nuxt-stripe/commit/bc3a877))
+  - Cleanup defu ([204483d](https://github.com/fuentesloic/nuxt-stripe/commit/204483d))
+  - Updating type definition with add template ([0c80308](https://github.com/fuentesloic/nuxt-stripe/commit/0c80308))
+  - Update package name ([b93dea5](https://github.com/fuentesloic/nuxt-stripe/commit/b93dea5))
 
 ### ❤️  Contributors
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Nuxt module for application using stripe.
 
 - [✨ &nbsp;Release Notes](/CHANGELOG.md)
-- [🏀 Online playground](https://stackblitz.com/github/fuentesloic/nuxt3-stripe?file=playground%2Fapp.vue)
+- [🏀 Online playground](https://stackblitz.com/github/fuentesloic/nuxt-stripe?file=playground%2Fapp.vue)
 
 ## Features
 
@@ -51,7 +51,7 @@ Use stripe inside pages or plugins
 
 <script setup lang="ts">
 // Import the function in your component or page
-import { useClientStripe } from 'nuxt3-stripe'
+import { useClientStripe } from '@unlok-co/nuxt-stripe'
 
 // Call the function to get the Stripe instance
 const stripe = useClientStripe()
@@ -63,25 +63,25 @@ const stripe = useClientStripe()
 
 ## Quick Setup
 
-1. Add `nuxt3-stripe` dependency to your project
+1. Add `@unlok-co/nuxt-stripe` dependency to your project
 
 ```bash
 # Using pnpm
-pnpm add -D nuxt3-stripe
+pnpm add -D @unlok-co/nuxt-stripe
 
 # Using yarn
-yarn add --dev nuxt3-stripe
+yarn add --dev @unlok-co/nuxt-stripe
 
 # Using npm
-npm install --save-dev nuxt3-stripe
+npm install --save-dev @unlok-co/nuxt-stripe
 ```
 
-2. Add `nuxt3-stripe` to the `modules` section of `nuxt.config.ts`
+2. Add `@unlok-co/nuxt-stripe` to the `modules` section of `nuxt.config.ts`
 
 ```ts
 export default defineNuxtConfig({
   modules: [
-    'nuxt3-stripe'
+    '@unlok-co/nuxt-stripe'
   ],
 })
 ```
@@ -101,7 +101,7 @@ STRIPE_API_KEY="sk_live_..."
 ```ts
 export default defineNuxtConfig({
   modules: [
-    'nuxt3-stripe'
+    '@unlok-co/nuxt-stripe'
   ],
   stripe: {
     // Server
@@ -159,14 +159,14 @@ The following stripe module is only for **nuxt 2** purpose and does **not** cove
 - [nuxt2-stripe - latest release](https://github.com/WilliamDASILVA/nuxt-stripe-module/releases/tag/3.0.0)
 
 <!-- Badges -->
-[npm-version-src]: https://img.shields.io/npm/v/nuxt3-stripe/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
-[npm-version-href]: https://npmjs.com/package/nuxt3-stripe
+[npm-version-src]: https://img.shields.io/npm/v/@unlok-co/nuxt-stripe/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-version-href]: https://npmjs.com/package/@unlok-co/nuxt-stripe
 
-[npm-downloads-src]: https://img.shields.io/npm/dm/nuxt3-stripe.svg?style=flat&colorA=18181B&colorB=28CF8D
-[npm-downloads-href]: https://npmjs.com/package/nuxt3-stripe
+[npm-downloads-src]: https://img.shields.io/npm/dm/@unlok-co/nuxt-stripe.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-href]: https://npmjs.com/package/@unlok-co/nuxt-stripe
 
-[license-src]: https://img.shields.io/npm/l/nuxt3-stripe.svg?style=flat&colorA=18181B&colorB=28CF8D
-[license-href]: https://npmjs.com/package/nuxt3-stripe
+[license-src]: https://img.shields.io/npm/l/@unlok-co/nuxt-stripe.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://npmjs.com/package/@unlok-co/nuxt-stripe
 
 [nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt.js
 [nuxt-href]: https://nuxt.com

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Nuxt module for application using stripe.
 
 ## Features
 
-This Nuxt module provides an easy way to integrate Stripe in your Nuxt application, both on the client-side and server-side. It utilizes the official `stripe` package for server-side usage and @stripe/stripe-js for the client-side.
+This Nuxt module provides an easy way to integrate Stripe in your Nuxt application, both on the client-side and server-side. It utilizes the official [stripe](https://www.npmjs.com/package/stripe) package for server-side usage and [@stripe/stripe-js](https://www.npmjs.com/package/@stripe/stripe-js) for the client-side.
 
 ### Server-side usage
 
@@ -121,7 +121,7 @@ Initial step: Clone this repository
 
 ```bash
 # Install dependencies
-yarn install 
+yarn install
 npm install
 
 # Generate type stubs
@@ -155,7 +155,7 @@ npm run release
 
 Disclaimer! Nuxt 2's end-of-life is planned for 31st Dec, 2023.
 The following stripe module is only for **nuxt 2** purpose and does **not** cover server side:
-- [nuxt2-stripe](https://github.com/WilliamDASILVA/nuxt-stripe-module)
+- [nuxt2-stripe - doc](https://github.com/WilliamDASILVA/nuxt-stripe-module)
 - [nuxt2-stripe - latest release](https://github.com/WilliamDASILVA/nuxt-stripe-module/releases/tag/3.0.0)
 
 <!-- Badges -->

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "nuxt3-stripe",
+  "name": "@unlok-co/nuxt-stripe",
   "version": "1.1.1",
   "description": "Nuxt module for stripe",
-  "repository": "https://github.com/fuentesloic/nuxt3-stripe",
+  "repository": "https://github.com/fuentesloic/nuxt-stripe",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,6 +1,6 @@
 <template>
   <main>
-    <h1>Nuxt 3 - Stripe module playground</h1>
+    <h1>Nuxt - Stripe module playground</h1>
     <section>
       <h2>Stripe client</h2>
       <code>

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "nuxt3-stripe-playground",
+  "name": "nuxt-stripe-playground",
   "type": "module",
   "scripts": {
     "dev": "nuxi dev",

--- a/src/module.ts
+++ b/src/module.ts
@@ -30,7 +30,7 @@ export interface ModuleOptions {
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
-    name: 'nuxt3-stripe',
+    name: '@unlok-co/nuxt-stripe',
     configKey: 'stripe',
     compatibility: {
       nuxt: '^3.0.0'

--- a/src/runtime/composables/useClientStripe.ts
+++ b/src/runtime/composables/useClientStripe.ts
@@ -3,7 +3,7 @@ import { useNuxtApp } from "#imports"
 /**
  * useClientStripe function
  *
- * This function is a helper to easily access the Stripe instance provided by the Nuxt 3 plugin.
+ * This function is a helper to easily access the Stripe instance provided by the Nuxt plugin.
  * It can be used in components or pages to interact with the Stripe.js library.
  * 
  */

--- a/src/runtime/plugins/stripe.client.ts
+++ b/src/runtime/plugins/stripe.client.ts
@@ -2,7 +2,7 @@ import { defineNuxtPlugin } from '#imports'
 import { loadStripe } from '@stripe/stripe-js'
 
 /**
- * Nuxt 3 plugin for Stripe
+ * Nuxt plugin for Stripe
  *
  * This plugin loads the Stripe.js library and provides a Stripe instance using the publishable key
  * from the Nuxt app configuration.

--- a/src/runtime/server/services/useServerStripe.ts
+++ b/src/runtime/server/services/useServerStripe.ts
@@ -4,10 +4,10 @@ import { H3Event } from 'h3'
 
 /**
  * useServerStripe is a utility function that initializes and returns a Stripe instance
- * for server-side usage in Nuxt 3. It ensures that only one instance of Stripe is created
+ * for server-side usage in Nuxt. It ensures that only one instance of Stripe is created
  * per event context, avoiding unnecessary re-initializations.
  *
- * @param {H3Event} event - The event object passed to the Nuxt 3 event handler
+ * @param {H3Event} event - The event object passed to the Nuxt event handler
  * @return {Promise<Stripe>} - A Promise that resolves to the Stripe server instance for the event context
  */
 export const useServerStripe = async(event: H3Event): Promise<Stripe> => {


### PR DESCRIPTION
From https://github.com/nuxt/modules/pull/677/files#r1248844412

Remove all notion of nuxt-3 in the code (and later on the plugin)
Migrate npm package into unlok-co npm's organisation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (not applicable as only impacting naming)

Note:  @flozero you will have to run `git remote set-url origin https://github.com/fuentesloic/nuxt-stripe.git` as I change the repo name to stay consistent cc @mitjans 